### PR TITLE
Add a description to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # update-api
 
-see the [project](https://github.com/VSCodium/vscodium/projects/1) and the [original issue](https://github.com/VSCodium/vscodium/issues/41) for more context 
+A small server that VSCodium calls to check for the latest release on GitHub. See the [Auto Update Support project](https://github.com/VSCodium/vscodium/projects/1) and the [original issue](https://github.com/VSCodium/vscodium/issues/41) for more context.
+
+**Note:** Even though the description for the `update.mode` setting in VSCodium says "The updates are fetched from a Microsoft online service", the build script [sets the `updateUrl` field](https://github.com/VSCodium/vscodium/blob/master/prepare_vscode.sh#L36) in `product.json` to https://vscodium.now.sh, so Microsoft's update service isn't actually called.


### PR DESCRIPTION
Just felt like adding a little context to the readme in case anyone lands on this repo not knowing what it is (and so they don't have to read through a project and/or an issue comment thread to figure it out).

New readme:

> # update-api
>
> A small server that VSCodium calls to check for the latest release on GitHub. See the [Auto Update Support project](https://github.com/VSCodium/vscodium/projects/1) and the [original issue](https://github.com/VSCodium/vscodium/issues/41) for more context.
>
> **Note:** Even though the description for the `update.mode` setting in VSCodium says "The updates are fetched from a Microsoft online service", the build script [sets the `updateUrl` field](https://github.com/VSCodium/vscodium/blob/master/prepare_vscode.sh#L36) in `product.json` to https://vscodium.now.sh, so Microsoft's update service isn't actually called.

Description comes from [this **@&zwnj;stripedpajamas** comment](https://github.com/VSCodium/vscodium/issues/411#issuecomment-640241736), and I added the additional note because it was something I was confused about until I found that line in `prepare_vscode.sh`.